### PR TITLE
init.sh now installs JDK instead of JRE

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -10,7 +10,7 @@ fi
 
 echo "installing JDK and Kafka..."
 
-su -c "yum -y install java-1.8.0-openjdk"
+su -c "yum -y install java-1.8.0-openjdk-devel"
 
 #disabling iptables
 /etc/init.d/iptables stop


### PR DESCRIPTION
Please see https://github.com/eucuepo/vagrant-kafka/issues/16 for details. This change will cause the `init.sh` script to install the JDK instead of the JRE, which will install some tools developers may want in their zookeeper environment.