### PR TITLE
Update init.sh to support old Kafka versions

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -5,7 +5,7 @@ echo "downloading kafka...$KAFKA_VERSION"
 #download kafka binaries if not present
 if [ ! -f  $KAFKA_TARGET/$KAFKA_NAME.tgz ]; then
    mkdir -p $KAFKA_TARGET
-   wget -O "$KAFKA_TARGET/$KAFKA_NAME.tgz" http://apache.mirrors.hoobly.com/kafka/"$KAFKA_VERSION/$KAFKA_NAME.tgz"
+   wget -O "$KAFKA_TARGET/$KAFKA_NAME.tgz" https://archive.apache.org/dist/kafka/"$KAFKA_VERSION/$KAFKA_NAME.tgz"
 fi
 
 echo "installing JDK and Kafka..."


### PR DESCRIPTION
Instead of using `apache.mirrors`, use `archive.apache` so you could fetch whatever Kafka version you want